### PR TITLE
Make possible to work with 15 min slots instead of hours

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.tibber",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.tibber",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "compatibility": ">=8.1.0",
   "platforms": [
     "local",

--- a/app.json
+++ b/app.json
@@ -444,7 +444,7 @@
           "en": "Current price is one of today's lowest [x] prices"
         },
         "titleFormatted": {
-          "en": "Current price is one of today's lowest [[ranked_hours]] prices"
+          "en": "Current price is one of today's lowest [[ranked_slots]] prices"
         },
         "args": [
           {
@@ -453,10 +453,10 @@
             "filter": "driver_id=home"
           },
           {
-            "name": "ranked_hours",
+            "name": "ranked_slots",
             "type": "number",
             "title": {
-              "en": "Hours"
+              "en": "Slots"
             },
             "placeholder": {
               "en": "1"
@@ -474,7 +474,7 @@
           "en": "Current price is one of today's highest [x] prices"
         },
         "titleFormatted": {
-          "en": "Current price is one of today's highest [[ranked_hours]] prices"
+          "en": "Current price is one of today's highest [[ranked_slots]] prices"
         },
         "args": [
           {
@@ -483,10 +483,10 @@
             "filter": "driver_id=home"
           },
           {
-            "name": "ranked_hours",
+            "name": "ranked_slots",
             "type": "number",
             "title": {
-              "en": "Hours"
+              "en": "Slots"
             },
             "placeholder": {
               "en": "1"
@@ -848,7 +848,7 @@
           "en": "Current price is one of the [x] lowest prices between [y] and [z]"
         },
         "titleFormatted": {
-          "en": "Current price is one of the [[ranked_hours]] lowest prices between [[start_time]] and [[end_time]]"
+          "en": "Current price is one of the [[ranked_slots]] lowest prices between [[start_time]] and [[end_time]]"
         },
         "args": [
           {
@@ -857,17 +857,17 @@
             "filter": "driver_id=home"
           },
           {
-            "name": "ranked_hours",
+            "name": "ranked_slots",
             "type": "number",
             "title": {
-              "en": "Amount of lowest hours"
+              "en": "Amount of lowest slots"
             },
             "placeholder": {
               "en": "1"
             },
             "min": 1,
-            "max": 24,
-            "step": 0.25
+            "max": 96,
+            "step": 1
           },
           {
             "name": "start_time",
@@ -1195,7 +1195,7 @@
           "en": "Current price !{{is|isn't}} one of today's lowest [x] prices"
         },
         "titleFormatted": {
-          "en": "Current price !{{is|isn't}} one of today's lowest [[ranked_hours]] prices"
+          "en": "Current price !{{is|isn't}} one of today's lowest [[ranked_slots]] prices"
         },
         "args": [
           {
@@ -1204,10 +1204,10 @@
             "filter": "driver_id=home"
           },
           {
-            "name": "ranked_hours",
+            "name": "ranked_slots",
             "type": "number",
             "title": {
-              "en": "Hours"
+              "en": "Slots"
             },
             "placeholder": {
               "en": "3"
@@ -1225,7 +1225,7 @@
           "en": "Current price !{{is|isn't}} one of today's highest [x] prices"
         },
         "titleFormatted": {
-          "en": "Current price !{{is|isn't}} one of today's highest [[ranked_hours]] prices"
+          "en": "Current price !{{is|isn't}} one of today's highest [[ranked_slots]] prices"
         },
         "args": [
           {
@@ -1234,10 +1234,10 @@
             "filter": "driver_id=home"
           },
           {
-            "name": "ranked_hours",
+            "name": "ranked_slots",
             "type": "number",
             "title": {
-              "en": "Hours"
+              "en": "Slots"
             },
             "placeholder": {
               "en": "3"

--- a/app.json
+++ b/app.json
@@ -867,7 +867,7 @@
             },
             "min": 1,
             "max": 24,
-            "step": 1
+            "step": 0.25
           },
           {
             "name": "start_time",

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -976,7 +976,7 @@ export class HomeDevice extends Device {
   #priceMinMaxComparator(
     options: {
       hours?: number;
-      ranked_hours?: number;
+      ranked_slots?: number;
     },
     args: { lowest: boolean },
   ): boolean {
@@ -992,7 +992,7 @@ export class HomeDevice extends Device {
   }
 
   #lowestPricesWithinTimeFrame(options: {
-    ranked_hours: number;
+    ranked_slots: number;
     start_time: TimeString;
     end_time: TimeString;
   }): boolean {

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -14,6 +14,7 @@ import {
   mean,
   sum,
   TimeString,
+  getCurrentSlot,
   min,
   max,
 } from '../../lib/helpers';
@@ -46,6 +47,7 @@ const deprecatedPriceLevelMap = {
 export class HomeDevice extends Device {
   #api!: TibberApi;
   #deviceLabel!: string;
+  #timeZone!: string;
   #insightId!: string;
   #prices: PriceData = { today: [] };
   #negativePriceEndsAt!: moment.Moment;
@@ -103,6 +105,7 @@ export class HomeDevice extends Device {
       );
     }
 
+    this.#timeZone = this.homey.clock.getTimezone();
     this.#deviceLabel = this.getName();
     this.#insightId = this.#deviceLabel
       .replace(/[^a-z0-9]/gi, '_')
@@ -418,24 +421,22 @@ export class HomeDevice extends Device {
   }
 
   async #handlePrice(now: moment.Moment) {
-    this.#prices.today = this.#api.hourlyPrices
-      .filter((p) =>
-        p.startsAt.tz(this.homey.clock.getTimezone()).isSame(now, 'day'),
-      )
+    this.#prices.today = this.#api.quarterPrices
+      .filter((p) => p.startsAt.tz(this.#timeZone).isSame(now, 'day'))
       .sort((a, b) => a.startsAt.diff(b.startsAt));
 
     // NOTE: this also updates capability values
     this.#updateLowestAndHighestPrice(now);
 
-    const currentHour = now.clone().startOf('hour');
+    const currentSlot = getCurrentSlot(now);
 
     const currentPrice = this.#prices.today.find((p) =>
-      currentHour.isSame(p.startsAt),
+      currentSlot.isSame(p.startsAt),
     );
 
     if (currentPrice === undefined) {
       this.log(
-        `Error finding current price info for system time ${currentHour.format()}. Abort.`,
+        `Error finding current price info for system time ${currentSlot.format()}. Abort.`,
         this.#prices.today,
       );
       return;
@@ -445,12 +446,12 @@ export class HomeDevice extends Device {
       driverId: 'home',
       deviceId: this.getData().id,
       now,
-      currentHour,
+      currentSlot,
       currentPrice,
       lowestToday: this.#prices.lowestToday,
       highestToday: this.#prices.highestToday,
       pricesToday: this.#prices.today,
-      hourlyPrices: this.#api.hourlyPrices,
+      quarterPrices: this.#api.quarterPrices,
     });
 
     const shouldUpdate =
@@ -715,9 +716,8 @@ export class HomeDevice extends Device {
         this.log("Set 'measure_energy_highest' capability to", highestEnergy);
       });
 
-    const timezone = this.homey.clock.getTimezone();
     const lowestTime = this.#prices.lowestToday?.startsAt
-      ? this.#prices.lowestToday.startsAt.tz(timezone).format('HH:mm')
+      ? this.#prices.lowestToday.startsAt.tz(this.#timeZone).format('HH:mm')
       : null;
     this.setCapabilityValue('time_price_lowest', lowestTime)
       .catch(console.error)
@@ -726,7 +726,7 @@ export class HomeDevice extends Device {
       });
 
     const highestTime = this.#prices.highestToday?.startsAt
-      ? this.#prices.highestToday.startsAt.tz(timezone).format('HH:mm')
+      ? this.#prices.highestToday.startsAt.tz(this.#timeZone).format('HH:mm')
       : null;
     this.setCapabilityValue('time_price_highest', highestTime)
       .catch(console.error)
@@ -948,7 +948,7 @@ export class HomeDevice extends Device {
     const now = moment();
     return averagePrice(
       this.log,
-      this.#api.hourlyPrices,
+      this.#api.quarterPrices,
       this.#prices,
       now,
       options,
@@ -966,7 +966,7 @@ export class HomeDevice extends Device {
     const now = moment();
     return priceExtremes(
       this.log,
-      this.#api.hourlyPrices,
+      this.#api.quarterPrices,
       this.#prices,
       now,
       options,
@@ -979,12 +979,10 @@ export class HomeDevice extends Device {
     start_time: TimeString;
     end_time: TimeString;
   }): boolean {
-    // we need to parse times w/o tz info here, so we need to assume a tz.
-    // consider moving into the helper function
-    const now = moment().tz(this.homey.clock.getTimezone());
+    const now = moment().tz(this.#timeZone);
     return lowestPricesWithinTimeFrame(
       this.log,
-      this.#api.hourlyPrices,
+      this.#api.quarterPrices,
       this.#prices,
       now,
       options,
@@ -1025,20 +1023,20 @@ export class HomeDevice extends Device {
 
   getDeviceData() {
     const now = moment();
-    const currentHour = now.clone().startOf('hour');
+    const currentSlot = getCurrentSlot(now);
     const currentPrice =
-      this.#prices.today.find((p) => currentHour.isSame(p.startsAt)) || 0;
+      this.#prices.today.find((p) => currentSlot.isSame(p.startsAt)) || 0;
 
     return {
       driverId: 'home',
       deviceId: this.getData().id,
       now,
-      currentHour,
+      currentSlot,
       currentPrice,
       lowestToday: this.#prices.lowestToday,
       highestToday: this.#prices.highestToday,
       pricesToday: this.#prices.today,
-      hourlyPrices: this.#api.hourlyPrices,
+      quarterPrices: this.#api.quarterPrices,
     };
   }
 }

--- a/drivers/home/device.ts
+++ b/drivers/home/device.ts
@@ -374,10 +374,12 @@ export class HomeDevice extends Device {
         await this.#generateConsumptionReport(now);
       }
 
-      const nextUpdateTime = moment()
-        .add(1, 'hour')
-        .startOf('hour')
-        .add(randomBetweenRange(0, 10), 'seconds');
+      // calculate time to next 15 min slot
+      const minutesToAdd = (15 - (now.minute() % 15)) % 15 || 15;
+      const nextUpdateTime = now.clone()
+        .add(minutesToAdd, 'minutes') // jump to next 15-min slot
+        .startOf('minute')
+        .add(randomBetweenRange(0, 3), 'seconds'); // add small jitter
 
       this.log(
         `Next time to run update is at system time ${nextUpdateTime.format()}`,

--- a/drivers/home/driver.flow.compose.json
+++ b/drivers/home/driver.flow.compose.json
@@ -313,7 +313,7 @@
           },
           "min": 1,
           "max": 24,
-          "step": 1
+          "step": 0.25
         },
         {
           "name": "start_time",

--- a/drivers/home/driver.flow.compose.json
+++ b/drivers/home/driver.flow.compose.json
@@ -230,14 +230,14 @@
         "en": "Current price is one of today's lowest [x] prices"
       },
       "titleFormatted": {
-        "en": "Current price is one of today's lowest [[ranked_hours]] prices"
+        "en": "Current price is one of today's lowest [[ranked_slots]] prices"
       },
       "args": [
         {
-          "name": "ranked_hours",
+          "name": "ranked_slots",
           "type": "number",
           "title": {
-            "en": "Hours"
+            "en": "Slots"
           },
           "placeholder": {
             "en": "1"
@@ -252,14 +252,14 @@
         "en": "Current price is one of today's highest [x] prices"
       },
       "titleFormatted": {
-        "en": "Current price is one of today's highest [[ranked_hours]] prices"
+        "en": "Current price is one of today's highest [[ranked_slots]] prices"
       },
       "args": [
         {
-          "name": "ranked_hours",
+          "name": "ranked_slots",
           "type": "number",
           "title": {
-            "en": "Hours"
+            "en": "Slots"
           },
           "placeholder": {
             "en": "1"
@@ -299,21 +299,21 @@
         "en": "Current price is one of the [x] lowest prices between [y] and [z]"
       },
       "titleFormatted": {
-        "en": "Current price is one of the [[ranked_hours]] lowest prices between [[start_time]] and [[end_time]]"
+        "en": "Current price is one of the [[ranked_slots]] lowest prices between [[start_time]] and [[end_time]]"
       },
       "args": [
         {
-          "name": "ranked_hours",
+          "name": "ranked_slots",
           "type": "number",
           "title": {
-            "en": "Amount of lowest hours"
+            "en": "Amount of lowest slots"
           },
           "placeholder": {
             "en": "1"
           },
           "min": 1,
-          "max": 24,
-          "step": 0.25
+          "max": 96,
+          "step": 1
         },
         {
           "name": "start_time",
@@ -554,14 +554,14 @@
         "en": "Current price !{{is|isn't}} one of today's lowest [x] prices"
       },
       "titleFormatted": {
-        "en": "Current price !{{is|isn't}} one of today's lowest [[ranked_hours]] prices"
+        "en": "Current price !{{is|isn't}} one of today's lowest [[ranked_slots]] prices"
       },
       "args": [
         {
-          "name": "ranked_hours",
+          "name": "ranked_slots",
           "type": "number",
           "title": {
-            "en": "Hours"
+            "en": "Slots"
           },
           "placeholder": {
             "en": "3"
@@ -576,14 +576,14 @@
         "en": "Current price !{{is|isn't}} one of today's highest [x] prices"
       },
       "titleFormatted": {
-        "en": "Current price !{{is|isn't}} one of today's highest [[ranked_hours]] prices"
+        "en": "Current price !{{is|isn't}} one of today's highest [[ranked_slots]] prices"
       },
       "args": [
         {
-          "name": "ranked_hours",
+          "name": "ranked_slots",
           "type": "number",
           "title": {
-            "en": "Hours"
+            "en": "Slots"
           },
           "placeholder": {
             "en": "3"

--- a/lib/comparators.test.ts
+++ b/lib/comparators.test.ts
@@ -87,7 +87,7 @@ describe('comparators (quarter-hourly)', () => {
           quarterHourlyPrices,
           priceData(now),
           now,
-          { ranked_hours: 3, hours: 12 },
+          { ranked_slots: 3, hours: 12 },
           { lowest: false },
         );
         expect(actual).toBe(false);

--- a/lib/comparators.test.ts
+++ b/lib/comparators.test.ts
@@ -9,66 +9,45 @@ const yesterday = '2023-01-31T00:00:00+01:00';
 const today = '2023-02-01T00:00:00+01:00';
 const tomorrow = '2023-02-02T00:00:00+01:00';
 
-const hourlyPrices: TransformedPriceEntry[] = [];
-for (const day of [yesterday, today, tomorrow]) {
+const quarterHourlyPrices: TransformedPriceEntry[] = [];
+
+for (const [dayOffset, day] of [yesterday, today, tomorrow].entries()) {
   const startsAt = moment(day);
-  let valueBase = 1;
-  for (let hour = 0; hour < 24; hour += 1) {
-    hourlyPrices.push({
+  const valueBase = 1 + dayOffset * 100; // Different base for each day to ensure uniqueness
+  for (let i = 0; i < 96; i += 1) {
+    quarterHourlyPrices.push({
       startsAt: startsAt.clone(),
-      total: hour + valueBase,
-      energy: hour + valueBase,
-      tax: hour + valueBase,
+      total: valueBase + i,
+      energy: valueBase + i,
+      tax: valueBase + i,
       level: 'NORMAL',
     });
-    startsAt.add(1, 'hour');
+    startsAt.add(15, 'minutes');
   }
-  valueBase += 10;
 }
 
 const priceData = (now: moment.Moment): PriceData => ({
-  today: hourlyPrices.slice(24, 48),
-  latest: hourlyPrices.find((p) => p.startsAt.isSame(now, 'hour')),
-  lowestToday: hourlyPrices[24],
-  highestToday: hourlyPrices[47],
+  today: quarterHourlyPrices.slice(96, 192),
+  latest: quarterHourlyPrices.find((p) => p.startsAt.isSame(now)),
+  lowestToday: quarterHourlyPrices[96],
+  highestToday: quarterHourlyPrices[191],
 });
 
-describe('comparators', () => {
-  describe('averagePrice', () => {
-    describe('below avg', () => {
-      test('today', () => {
-        expect(true);
-      });
-
-      test('for the next X hours', () => {
-        expect(true);
-      });
-    });
-  });
-
+describe('comparators (quarter-hourly)', () => {
   describe('priceExtremes', () => {
     describe('today', () => {
       each`
         now                            | expectedLowest | expectedHighest
-        ${'2023-02-01T00:17:06+01:00'} | ${true}        | ${false}
-        ${'2023-02-01T02:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T04:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T06:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T08:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T10:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T12:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T16:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T18:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T20:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T22:17:06+01:00'} | ${false}       | ${false}
-        ${'2023-02-01T23:17:06+01:00'} | ${false}       | ${true}
-      `.describe('today: $now', ({ now, expectedLowest, expectedHighest }) => {
+        ${'2023-02-01T00:15:00+01:00'} | ${true}        | ${false}
+        ${'2023-02-01T12:00:00+01:00'} | ${false}       | ${false}
+        ${'2023-02-01T23:45:00+01:00'} | ${false}       | ${true}
+      `.describe('slot: $now', ({ now, expectedLowest, expectedHighest }) => {
         test('lowest', () => {
           const actual = priceExtremes(
             logger,
-            hourlyPrices,
-            priceData(now),
-            now,
+            quarterHourlyPrices,
+            priceData(moment(now)),
+            moment(now),
             {},
             { lowest: true },
           );
@@ -78,9 +57,9 @@ describe('comparators', () => {
         test('highest', () => {
           const actual = priceExtremes(
             logger,
-            hourlyPrices,
-            priceData(now),
-            now,
+            quarterHourlyPrices,
+            priceData(moment(now)),
+            moment(now),
             {},
             { lowest: false },
           );
@@ -89,12 +68,12 @@ describe('comparators', () => {
       });
 
       test('for the next X hours', () => {
-        const timeTodayWithLowestPrice = moment('2023-02-01T00:32:27+01:00');
+        const now = moment('2023-02-01T00:15:00+01:00');
         const actual = priceExtremes(
           logger,
-          hourlyPrices,
-          priceData(timeTodayWithLowestPrice),
-          timeTodayWithLowestPrice,
+          quarterHourlyPrices,
+          priceData(now),
+          now,
           { hours: 3 },
           { lowest: false },
         );
@@ -102,12 +81,12 @@ describe('comparators', () => {
       });
 
       test('among the X for the next Y hours', () => {
-        const timeTodayWithLowestPrice = moment('2023-02-01T00:32:27+01:00');
+        const now = moment('2023-02-01T00:15:00+01:00');
         const actual = priceExtremes(
           logger,
-          hourlyPrices,
-          priceData(timeTodayWithLowestPrice),
-          timeTodayWithLowestPrice,
+          quarterHourlyPrices,
+          priceData(now),
+          now,
           { ranked_hours: 3, hours: 12 },
           { lowest: false },
         );

--- a/lib/comparators.ts
+++ b/lib/comparators.ts
@@ -70,7 +70,7 @@ export const averagePrice = (
 
 export interface PriceExtremesOptions {
   hours?: number;
-  ranked_hours?: number;
+  ranked_slots?: number;
 }
 
 export interface PriceExtremesArguments {
@@ -85,7 +85,7 @@ export const priceExtremes = (
   options: PriceExtremesOptions,
   { lowest }: PriceExtremesArguments,
 ): boolean => {
-  const { hours, ranked_hours: rankedSlots } = options;
+  const { hours, ranked_slots: rankedSlots } = options;
   if (hours === 0 || rankedSlots === 0) return false;
 
   const slotCount = hours ? hours * SLOTS_PER_HOUR : undefined;
@@ -153,7 +153,7 @@ export const priceExtremes = (
 };
 
 export interface LowestPricesWithinTimeFrameOptions {
-  ranked_hours: number;
+  ranked_slots: number;
   start_time: TimeString;
   end_time: TimeString;
 }
@@ -166,7 +166,7 @@ export const lowestPricesWithinTimeFrame = (
   options: LowestPricesWithinTimeFrameOptions,
 ): boolean => {
   const {
-    ranked_hours: rankedSlots,
+    ranked_slots: rankedSlots,
     start_time: startTime,
     end_time: endTime,
   } = options;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -6,13 +6,21 @@ export const isSomeString = (value: unknown): boolean =>
 export const nonNullable = <T>(value: T): value is NonNullable<T> =>
   value !== null && value !== undefined;
 
-export const parseTimeString = (time: TimeString): moment.Moment => {
+export const parseTimeString = (
+  time: TimeString,
+  timeZone: string,
+): moment.Moment => {
   const [h, m] = time.split(':');
   return moment
-    .tz('Europe/Oslo')
-    .hour(Number(h))
-    .minute(Number(m))
+    .tz({ hour: Number(h), minute: Number(m) }, timeZone)
     .startOf('minute');
+};
+
+export const getCurrentSlot = (now: moment.Moment): moment.Moment => {
+  const clone = now.clone().startOf('minute');
+  const minute = clone.minute();
+  clone.minute(Math.floor(minute / 15) * 15);
+  return clone;
 };
 
 // takes from end of array if `quantity` is negative

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -37,7 +37,7 @@ export const queries = {
       viewer {
         home(id:"${homeId}") {
           currentSubscription {
-            priceInfo {
+            priceInfo(resolution: QUARTER_HOURLY) {
               today {
                 total
                 energy

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "com.tibber",
-      "version": "1.10.0",
+      "version": "1.10.2",
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.7.9",
@@ -29,7 +29,7 @@
         "@types/jest": "^29.4.0",
         "@types/lodash": "^4.14.191",
         "@types/newrelic": "^9.4.0",
-        "@types/node": "^18.19.112",
+        "@types/node": "^18.19.129",
         "@types/source-map-support": "^0.5.4",
         "@types/ws": "^8.5.4",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
@@ -1653,9 +1653,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
-      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "version": "18.19.129",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.129.tgz",
+      "integrity": "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8435,9 +8435,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
-      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "version": "18.19.129",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.129.tgz",
+      "integrity": "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==",
       "requires": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/jest": "^29.4.0",
     "@types/lodash": "^4.14.191",
     "@types/newrelic": "^9.4.0",
-    "@types/node": "^18.19.112",
+    "@types/node": "^18.19.129",
     "@types/source-map-support": "^0.5.4",
     "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^5.53.0",


### PR DESCRIPTION
Make possible to work with 15 min slots instead of hours
The triggers/conditions like "for the next N hours" lrft as is, but hours is internally re-calculated to quarter slots.
The triggers/conditions like "among N lowest/hghest prices" is changed to "among N lowest/highest slots"